### PR TITLE
Hotfix: Swagger documentation

### DIFF
--- a/app/Http/Controllers/API/v1/EmailVerificationController.php
+++ b/app/Http/Controllers/API/v1/EmailVerificationController.php
@@ -61,7 +61,7 @@ class EmailVerificationController extends Controller
      * @param int $userId
      * @return JsonResponse
      */
-    #[OA\Post(
+    #[OA\Get(
         path: '/v1/email-verify/{id}',
         tags: ['Authentication'],
         parameters: [

--- a/public/swagger.json
+++ b/public/swagger.json
@@ -6,7 +6,7 @@
     },
     "servers": [
         {
-            "url": "http://3.79.151.249:86/api/"
+            "url": "http://3.68.186.228:86/api/"
         },
         {
             "url": "http://172.19.0.1:86/api/"
@@ -322,11 +322,11 @@
             }
         },
         "/v1/email-verify/{id}": {
-            "post": {
+            "get": {
                 "tags": [
                     "Authentication"
                 ],
-                "operationId": "7868c15c63b2a521761e0536980591ab",
+                "operationId": "6b6394b2b34f8646c26f9546009eece9",
                 "parameters": [
                     {
                         "name": "id",


### PR DESCRIPTION
- Email verify now has GET method, instead POST